### PR TITLE
Locking to last known working version-- this module requires update t…

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "<= 0.12.7"
 }


### PR DESCRIPTION
…o destroy trigger resources for versions newer than 0.12.7.

There are currently issues running this module on versions later than this, so until this is updated to address this on latest, I am having it limit `required_versions` to less than or equal to 0.12.7, i.e:

```bash
$ ./terraform0.12.10 init

Error: Unsupported Terraform Core version
```